### PR TITLE
UI_LOGページにバックスクロール機能とキー長押しリピート機能を追加

### DIFF
--- a/CH32X035/minyasx-v2/src/greenpak/greenpak_program.c
+++ b/CH32X035/minyasx-v2/src/greenpak/greenpak_program.c
@@ -17,17 +17,6 @@ static void gp_erase_page(uint8_t addr7, uint8_t page) {
     Delay_Ms(GP_ERASE_T_MS);  // 自己タイミング消去の完了待ち
 }
 
-static void gp_erase_range(uint8_t addr7, uint16_t base, uint16_t size) {
-    if (!size) return;
-    uint16_t start_page = (base) / GP_PAGE_SIZE;
-    uint16_t end_page = (base + size - 1) / GP_PAGE_SIZE;
-    if (start_page > 15) start_page = 15;
-    if (end_page > 15) end_page = 15;
-    for (uint16_t p = start_page; p <= end_page; ++p) {
-        gp_erase_page(addr7, (uint8_t)p);
-    }
-}
-
 // 既存の連続書き込みを流用（そのまま）
 extern void gp_write_seq(uint8_t addr7, uint16_t start, const uint8_t *data, uint16_t len);
 
@@ -35,7 +24,6 @@ extern void gp_write_seq(uint8_t addr7, uint16_t start, const uint8_t *data, uin
 void gp_program_with_erase(uint8_t addr7, uint16_t base, const uint8_t *img, uint16_t size) {
     if (!size) return;
     uint8_t nvm_addr7 = (uint8_t)((addr7 & 0xfc) + 2);  // NVMアドレスに変換 (addrは0x08,0x10,0x18,0x20,0x28のいずれか)
-                                                        //    gp_erase_range(addr7, base, size);                  // 先に消去
     for (int i = 0; i < 16; i++) {
         // 16バイトずつウエイトを入れて書く
         ui_logf(UI_LOG_LEVEL_INFO, "%d ", 16 - i);

--- a/CH32X035/minyasx-v2/src/ui/ui_log_buffer.c
+++ b/CH32X035/minyasx-v2/src/ui/ui_log_buffer.c
@@ -1,0 +1,139 @@
+#include "ui_log_buffer.h"
+
+#include <string.h>
+
+void ui_log_buffer_init(ui_log_buffer_t* buf) {
+    // すべてのフィールドを初期化
+    memset(buf->lines, 0, sizeof(buf->lines));
+    buf->head = 0;
+    buf->count = 0;
+    buf->view_offset = 0;
+    buf->scroll_locked = false;
+}
+
+void ui_log_buffer_add_line(ui_log_buffer_t* buf, const char* line) {
+    // 新しい行を追加（リングバッファの次の位置へ）
+    buf->head = (buf->head + 1) % 100;
+
+    // 行をコピー（最大20文字 + NULL終端）
+    strncpy(buf->lines[buf->head], line, 20);
+    buf->lines[buf->head][20] = '\0';  // NULL終端を保証
+
+    // カウントを更新（最大100）
+    if (buf->count < 100) {
+        buf->count++;
+    }
+
+    // スクロールロック中の場合、表示範囲のチェック
+    if (buf->scroll_locked) {
+        // 表示中の最古行のオフセット（view_offsetから6行前）
+        int16_t oldest_displayed = buf->view_offset - 6;
+
+        // バッファ内で利用可能な最古行のオフセット
+        int16_t oldest_available = -(int16_t)(buf->count - 1);
+
+        // 表示中の最古行が押し出される場合
+        if (oldest_displayed < oldest_available) {
+            // 表示位置を1行新しい方へずらす
+            buf->view_offset++;
+
+            // 最新に達したらロック解除
+            if (buf->view_offset >= 0) {
+                buf->scroll_locked = false;
+                buf->view_offset = 0;
+            }
+        }
+    }
+}
+
+void ui_log_buffer_get_view(ui_log_buffer_t* buf, char lines[7][21]) {
+    // 表示する7行分を取得
+    // view_offset = 0 の場合、最新から7行
+    // view_offset = -10 の場合、10行前から7行
+
+    // すべての行をクリア
+    for (int i = 0; i < 7; i++) {
+        memset(lines[i], ' ', 20);
+        lines[i][20] = '\0';
+    }
+
+    // バッファが空の場合は空行を返す
+    if (buf->count == 0) {
+        return;
+    }
+
+    // 表示開始位置を計算（最新行からのオフセット）
+    int16_t start_offset = buf->view_offset - 6;
+
+    // 7行分をコピー
+    for (int i = 0; i < 7; i++) {
+        int16_t line_offset = start_offset + i;
+
+        // オフセットが有効範囲内かチェック
+        // 有効範囲: -(count-1) <= line_offset <= 0
+        if (line_offset >= -(int16_t)(buf->count - 1) && line_offset <= 0) {
+            // リングバッファ内のインデックスを計算
+            int16_t index = (int16_t)buf->head + line_offset;
+            if (index < 0) {
+                index += 100;
+            }
+            index = index % 100;
+
+            // 行をコピー
+            strncpy(lines[i], buf->lines[index], 20);
+            lines[i][20] = '\0';
+        }
+    }
+}
+
+void ui_log_buffer_scroll_up(ui_log_buffer_t* buf) {
+    // 古い方へスクロール（画面を上に移動）
+
+    // バッファが7行以下の場合はスクロールしない
+    if (buf->count <= 7) {
+        return;
+    }
+
+    // スクロールロックを有効化
+    buf->scroll_locked = true;
+
+    // オフセットを減らす（古い方へ）
+    buf->view_offset--;
+
+    // 最古行を超えないように制限
+    int16_t oldest_offset = -(int16_t)(buf->count - 7);
+    if (buf->view_offset < oldest_offset) {
+        buf->view_offset = oldest_offset;
+    }
+}
+
+void ui_log_buffer_scroll_down(ui_log_buffer_t* buf) {
+    // 新しい方へスクロール（画面を下に移動）
+
+    // すでに最新の場合は何もしない
+    if (buf->view_offset >= 0) {
+        buf->scroll_locked = false;
+        buf->view_offset = 0;
+        return;
+    }
+
+    // オフセットを増やす（新しい方へ）
+    buf->view_offset++;
+
+    // 最新に達したらロック解除
+    if (buf->view_offset >= 0) {
+        buf->scroll_locked = false;
+        buf->view_offset = 0;
+    }
+}
+
+void ui_log_buffer_unlock(ui_log_buffer_t* buf) {
+    // スクロールロックを解除し、最新に戻る
+    buf->scroll_locked = false;
+    buf->view_offset = 0;
+}
+
+int16_t ui_log_buffer_get_offset(ui_log_buffer_t* buf) {
+    // 現在の表示オフセットを返す
+    return buf->view_offset;
+}

--- a/CH32X035/minyasx-v2/src/ui/ui_log_buffer.h
+++ b/CH32X035/minyasx-v2/src/ui/ui_log_buffer.h
@@ -1,0 +1,39 @@
+#ifndef UI_LOG_BUFFER_H
+#define UI_LOG_BUFFER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// ログバッファの管理構造体
+// 最大100行のログをリングバッファで保持し、バックスクロール機能を提供
+typedef struct {
+    char lines[100][21];  // 100行×21文字のリングバッファ
+    uint16_t head;        // 最新行のインデックス（0-99）
+    uint16_t count;       // 格納されている行数（0-100）
+    int16_t view_offset;  // 表示オフセット（0=最新、負数=過去）
+    bool scroll_locked;   // trueの場合、ユーザーがバックスクロール中
+} ui_log_buffer_t;
+
+// ログバッファの初期化
+void ui_log_buffer_init(ui_log_buffer_t* buf);
+
+// ログバッファに1行追加（最大21文字、NULL終端）
+void ui_log_buffer_add_line(ui_log_buffer_t* buf, const char* line);
+
+// 現在の表示位置から7行分を取得
+// lines[0]が最も古い行、lines[6]が最も新しい行
+void ui_log_buffer_get_view(ui_log_buffer_t* buf, char lines[7][21]);
+
+// 古い方へスクロール（画面を上にスクロール）
+void ui_log_buffer_scroll_up(ui_log_buffer_t* buf);
+
+// 新しい方へスクロール（画面を下にスクロール）
+void ui_log_buffer_scroll_down(ui_log_buffer_t* buf);
+
+// スクロールロックを解除し、最新に戻る
+void ui_log_buffer_unlock(ui_log_buffer_t* buf);
+
+// 現在の表示オフセットを取得（0=最新、負数=何行前）
+int16_t ui_log_buffer_get_offset(ui_log_buffer_t* buf);
+
+#endif  // UI_LOG_BUFFER_H

--- a/CH32X035/minyasx-v2/src/ui/ui_page_log.c
+++ b/CH32X035/minyasx-v2/src/ui/ui_page_log.c
@@ -1,19 +1,113 @@
-#include "ui_control.h"
+#include "ui_page_log.h"
 
-// log page
+#include <stdio.h>
+#include <string.h>
+
+#include "ui_control.h"
+#include "ui_log_buffer.h"
+
+// ログバッファのインスタンス
+static ui_log_buffer_t log_buffer;
+
+// 1行分の文字バッファリング用
+static char current_line[21];
+static uint8_t current_line_pos = 0;
+
+// 初期化済みフラグ
+static bool initialized = false;
+
+// 前方宣言
 void ui_page_log_keyin(ui_page_context_t* pctx, ui_key_mask_t keys);
+void ui_page_log_poll(ui_page_context_t* pctx, uint32_t systick_ms);
 
 void ui_page_log_init(ui_page_context_t* pcon) {
     pcon->enter = NULL;
-    pcon->poll = NULL;
+    pcon->poll = ui_page_log_poll;
     pcon->keyin = ui_page_log_keyin;
-    pcon->scroll_enable = true;
-    pcon->scroll_keepheader = true;
-    ui_cursor(pcon->page, 0, 0);
-    ui_print(pcon->page, "========[Log]======\n");
+    pcon->scroll_enable = false;      // バックスクロール機能を使うので自動スクロールは無効
+    pcon->scroll_keepheader = false;  // 手動で管理するので無効
+
+    // ログバッファの初期化（初回のみ）
+    if (!initialized) {
+        ui_log_buffer_init(&log_buffer);
+        memset(current_line, 0, sizeof(current_line));
+        current_line_pos = 0;
+        initialized = true;
+    }
+
+    // 初期表示
+    ui_page_log_refresh(pcon);
+}
+
+void ui_page_log_refresh(ui_page_context_t* pctx) {
+    // バッファから7行分を取得
+    char view_lines[7][21];
+    ui_log_buffer_get_view(&log_buffer, view_lines);
+
+    // ヘッダー行の作成
+    int16_t offset = ui_log_buffer_get_offset(&log_buffer);
+    char header[22];
+    if (offset == 0) {
+        snprintf(header, 22, "====[Log: Latest]===");
+    } else {
+        snprintf(header, 22, "====[Log -%3d]====", -offset);
+    }
+
+    // バッファをクリア
+    for (int y = 0; y < 8; y++) {
+        for (int x = 0; x < 21; x++) {
+            pctx->buf[y][x] = ' ';
+        }
+    }
+
+    // ヘッダー行を書き込み
+    for (int x = 0; x < 20 && header[x] != '\0'; x++) {
+        pctx->buf[0][x] = header[x];
+    }
+
+    // ログ行を書き込み（1-7行目）
+    for (int i = 0; i < 7; i++) {
+        for (int x = 0; x < 20 && view_lines[i][x] != '\0'; x++) {
+            pctx->buf[i + 1][x] = view_lines[i][x];
+        }
+    }
+
+    // 現在のページの場合、OLEDに反映
+    if (ui_get_current_page() == pctx->page) {
+        // OLEDを更新
+        for (int y = 0; y < 8; y++) {
+            OLED_cursor(0, y);
+            for (int x = 0; x < 21; x++) {
+                OLED_write(pctx->buf[y][x]);
+            }
+        }
+    }
+}
+
+void ui_page_log_poll(ui_page_context_t* pctx, uint32_t systick_ms) {
+    // 定期的に表示を更新（スクロールロックされていない場合のみ）
+    static uint32_t last_refresh = 0;
+    if (!log_buffer.scroll_locked && (systick_ms - last_refresh > 100)) {
+        last_refresh = systick_ms;
+        if (ui_get_current_page() == pctx->page) {
+            ui_page_log_refresh(pctx);
+        }
+    }
 }
 
 void ui_page_log_keyin(ui_page_context_t* pctx, ui_key_mask_t keys) {
+    bool need_refresh = false;
+
+    if (keys & UI_KEY_UP) {
+        // 古い方へスクロール
+        ui_log_buffer_scroll_up(&log_buffer);
+        need_refresh = true;
+    }
+    if (keys & UI_KEY_DOWN) {
+        // 新しい方へスクロール
+        ui_log_buffer_scroll_down(&log_buffer);
+        need_refresh = true;
+    }
     if (keys & UI_KEY_RIGHT) {
         // メインページに戻る
         ui_change_page(UI_PAGE_MAIN);
@@ -25,5 +119,40 @@ void ui_page_log_keyin(ui_page_context_t* pctx, ui_key_mask_t keys) {
     if (keys & UI_KEY_ENTER) {
         // メニューページに戻る
         ui_change_page(UI_PAGE_MENU);
+    }
+
+    if (need_refresh) {
+        ui_page_log_refresh(pctx);
+    }
+}
+
+void ui_page_log_write_char(char c) {
+    // 1行分のバッファリング
+    if (c == '\n') {
+        // 改行が来たら1行をログバッファに追加
+        current_line[current_line_pos] = '\0';
+        ui_log_buffer_add_line(&log_buffer, current_line);
+
+        // バッファをクリア
+        memset(current_line, 0, sizeof(current_line));
+        current_line_pos = 0;
+    } else if (c == '\r') {
+        // キャリッジリターンは行の先頭に戻る
+        current_line_pos = 0;
+    } else {
+        // 通常の文字
+        if (current_line_pos < 20) {
+            current_line[current_line_pos] = c;
+            current_line_pos++;
+        } else {
+            // 行が21文字を超えた場合は自動改行
+            current_line[20] = '\0';
+            ui_log_buffer_add_line(&log_buffer, current_line);
+
+            // 新しい行を開始
+            memset(current_line, 0, sizeof(current_line));
+            current_line[0] = c;
+            current_line_pos = 1;
+        }
     }
 }

--- a/CH32X035/minyasx-v2/src/ui/ui_page_log.h
+++ b/CH32X035/minyasx-v2/src/ui/ui_page_log.h
@@ -1,0 +1,15 @@
+#ifndef UI_PAGE_LOG_H
+#define UI_PAGE_LOG_H
+
+#include "ui_control.h"
+
+// UI_LOGÚü¸n
+void ui_page_log_init(ui_page_context_t* pcon);
+
+// UI_LOGÚü¸xn‡WøM¼ui_writeK‰|pŒ‹	
+void ui_page_log_write_char(char c);
+
+// UI_LOGÚü¸nh:ô°
+void ui_page_log_refresh(ui_page_context_t* pctx);
+
+#endif  // UI_PAGE_LOG_H


### PR DESCRIPTION
## 追加機能

### 1. ログバックスクロール機能
- 最大100行のログ履歴をリングバッファで保持
- UP/DOWNキーで過去のログをスクロール可能
- バックスクロール中も裏で新規ログは追加され続ける
- 表示範囲が100行バッファから押し出される場合は自動調整
- ヘッダー行に表示オフセットを表示 ([Log: Latest] または [Log -10])

### 2. キー長押しリピート機能
- UP/DOWNキーの長押し（500ms以上）でリピート開始
- リピート中は100msごとに連続入力
- 誤操作防止のためUP/DOWNキーのみリピート対象

## 実装内容

### 新規ファイル
- src/ui/ui_log_buffer.h: ログバッファモジュールのヘッダー
- src/ui/ui_log_buffer.c: リングバッファとスクロール管理の実装
- src/ui/ui_page_log.h: UI_LOGページのAPI定義

### 修正ファイル
- src/ui/ui_page_log.c: バックスクロール機能の実装
- src/ui/ui_control.c: キー長押しリピート機能の実装
- src/greenpak/greenpak_program.c: 未使用関数の削除